### PR TITLE
Fix VSCode 

### DIFF
--- a/core/src/main/java/io/smallrye/safer/annotations/SaferAnnotationProcessor.java
+++ b/core/src/main/java/io/smallrye/safer/annotations/SaferAnnotationProcessor.java
@@ -126,7 +126,7 @@ public class SaferAnnotationProcessor extends AbstractProcessor {
         // there can be only a single file, but in case your overrides are in your current project, they won't be compiled yet
         // so you can only load them via the Javac Mirror API, and not the ServiceLoader, which requires them to be compiled.
         try {
-            FileObject resource = this.processingEnv.getFiler().getResource(StandardLocation.CLASS_PATH, "",
+            FileObject resource = this.processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "",
                     "META-INF/services/" + DefinitionOverride.class.getName());
             try (BufferedReader reader = new BufferedReader(resource.openReader(true))) {
                 String line = null;
@@ -137,7 +137,7 @@ public class SaferAnnotationProcessor extends AbstractProcessor {
             }
         } catch (FileNotFoundException e) {
             // ignore this one, it's fine if it doesn't exist
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
             // Shrug
             e.printStackTrace();
         }


### PR DESCRIPTION
JDT (when used in at least vscode) does not support CLASS_PATH and throws an IAE. Use CLASS_OUTPUT instead, and eat any future IAEs, since they aren't a halting condition.

NOTE: This PR is not heavily tested